### PR TITLE
Improve layout and peer-support styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,3 +1,101 @@
-body {font-family: system-ui, sans-serif; margin: 0; padding: 0 1rem; line-height: 1.5;}
-header {text-align: center; margin: 2rem 0;}
-#disclaimer {background:#ffe4e4; padding:1rem; border-left:6px solid #ff5656;}
+/*
+  Purpose: Styling for Reach Collective site.
+  Inputs: HTML structure in index.html.
+  Outputs: Responsive layout and accessible color scheme.
+  Complexity: O(1) style application.
+*/
+
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.container {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+header {
+  text-align: center;
+  margin: 2rem 0;
+}
+
+.logo {
+  max-width: 120px;
+}
+
+h1,
+h2,
+h3 {
+  color: #39B54A;
+}
+
+a {
+  color: #39B54A;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #2a8c3b;
+}
+
+.steps {
+  padding-left: 1.2rem;
+}
+
+#disclaimer {
+  background: #ffeaea;
+  padding: 1rem;
+  border-left: 4px solid #ff5656;
+  margin: 1rem 0;
+}
+
+#disclaimer summary {
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.resource-list {
+  list-style: none;
+  padding: 0;
+}
+
+.resource-list li {
+  display: flex;
+  align-items: flex-start;
+  margin: 0.5rem 0;
+}
+
+.resource-list .icon {
+  margin-right: 0.5rem;
+}
+
+.start-chat {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: #39B54A;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.start-chat:hover {
+  background: #2a8c3b;
+}
+
+footer {
+  text-align: center;
+  color: #666;
+  font-size: 0.875rem;
+  margin: 2rem 0;
+}
+
+footer a {
+  color: #39B54A;
+}

--- a/index.html
+++ b/index.html
@@ -1,3 +1,9 @@
+<!--
+  Purpose: Reach Collective landing page for peer support.
+  Inputs: User interaction via links and chat widget.
+  Outputs: Markup with embedded Tawk.to chat.
+  Complexity: O(1) static rendering.
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -11,30 +17,47 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
-  <header>
-    <h1>Reach</h1>
-    <p>You don’t have to be in crisis to reach out.</p>
-  </header>
+  <button id="start-chat" class="start-chat" type="button">Start Chat</button>
+  <div class="container">
+    <header>
+      <img src="assets/reach-logo.png" alt="Reach Collective logo" class="logo" />
+      <h1>Reach</h1>
+      <p class="tagline">Every At-risk Community with Human connection</p>
+    </header>
 
   <main>
     <h2>How this works</h2>
-    <p>Text our number or start a chat (bottom-right). A volunteer listener will answer as soon as possible.</p>
+    <ol class="steps">
+      <li>Text our number or click chat.</li>
+      <li>You'll connect with a volunteer listener.</li>
+      <li>No pressure, just someone who cares.</li>
+    </ol>
 
-    <section id="disclaimer">
-      <strong>Disclaimer – Read First:</strong>
-      This is <em>peer support only</em>. We are not medical professionals.
-      If you feel unsafe with your thoughts, call 988 or 911 immediately.
-    </section>
+    <details id="disclaimer">
+      <summary>⚠︎ Read this before continuing</summary>
+      <p>
+        This is <em>peer support only</em>. We are not medical professionals.
+        If you feel unsafe with your thoughts, call 988 or 911 immediately.
+      </p>
+    </details>
 
     <section id="resources">
       <h3>Emergency & Helpful Links</h3>
-      <ul>
-        <li><a href="tel:988">988 Suicide &amp; Crisis Lifeline</a></li>
-        <li>Text <b>HOME</b> to <b>741741</b> (Crisis Text Line)</li>
-        <li><a href="https://findtreatment.gov" target="_blank">Find treatment near you</a></li>
+      <ul class="resource-list">
+        <li><span class="icon">📞</span><a href="tel:988">988 Suicide &amp; Crisis Lifeline</a></li>
+        <li><span class="icon">💬</span>Text <b>HOME</b> to <b>741741</b> (Crisis Text Line)</li>
+        <li><span class="icon">🌐</span><a href="https://findtreatment.gov" target="_blank">Find treatment near you</a></li>
       </ul>
     </section>
   </main>
+    <footer>
+      <p>
+        Peer support only • Volunteer-powered • Reach Collective 2025 |
+        <a href="terms.html">Terms</a> •
+        <a href="privacy.html">Privacy</a>
+      </p>
+    </footer>
+  </div>
 
   <!--Start of Tawk.to Script-->
   <script type="text/javascript">
@@ -51,5 +74,27 @@
     })();
   </script>
   <!--End of Tawk.to Script-->
+  <script>
+    document.getElementById('start-chat').addEventListener('click', function () {
+      if (window.Tawk_API && Tawk_API.toggle) {
+        Tawk_API.toggle();
+      }
+    });
+
+    var idleTimer;
+    function openChat() {
+      if (window.Tawk_API && Tawk_API.toggle) {
+        Tawk_API.toggle();
+      }
+    }
+    function resetTimer() {
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(openChat, 20000);
+    }
+    ['mousemove', 'keydown', 'scroll'].forEach(function (evt) {
+      document.addEventListener(evt, resetTimer);
+    });
+    resetTimer();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- center page content and add Reach logo & tagline
- present steps in an ordered list
- collapse disclaimer and revamp emergency links
- add footer and floating **Start Chat** button
- color theme and layout tweaks in CSS
- auto-open chat widget after 20 seconds idle

## Testing
- `tidy -errors -q index.html` *(fails: command not found)*
- `xmllint --html --noout index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e5ccc878832bbed363d231609215