### PR TITLE
Fix asset references and HTML entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ scripts/setup.sh installer and then use `tidy` and `xmllint`.
 1. Install a local server (e.g., npm install -g serve).
 2. Run serve . from the project root to preview at http://localhost:5000.
 3. Lint HTML with tidy -q -e *.html.
-4. Contribute via pull requests—run npm run lint before submitting.
+4. Contribute via pull requests—run tidy and xmllint before submitting.

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="description" content="Project Reach – Peer-support resources for emotional well-being" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha384-..." crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-<link rel="icon" href="assets/favicon.ico" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
+<link rel="icon" href="assets/favicon.png" />
 <link rel="stylesheet" href="assets/styles.css" />
 <script src="https://cdn.tailwindcss.com"></script>
 <title>Code of Conduct – Reach Collective</title>

--- a/faq.html
+++ b/faq.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="description" content="Project Reach – Peer-support resources for emotional well-being" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha384-..." crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-<link rel="icon" href="assets/favicon.ico" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
+<link rel="icon" href="assets/favicon.png" />
 <link rel="stylesheet" href="assets/styles.css" />
 <script src="https://cdn.tailwindcss.com"></script>
 <title>FAQ – Reach Collective</title>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="description" content="Project Reach – Peer-support resources for emotional well-being" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha384-..." crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-<link rel="icon" href="assets/favicon.ico" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
+<link rel="icon" href="assets/favicon.png" />
 <link rel="stylesheet" href="assets/styles.css" />
 <script src="https://cdn.tailwindcss.com"></script>
 <title>Reach – Peer Support</title>

--- a/privacy.html
+++ b/privacy.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="description" content="Project Reach – Peer-support resources for emotional well-being" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha384-..." crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-<link rel="icon" href="assets/favicon.ico" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
+<link rel="icon" href="assets/favicon.png" />
 <link rel="stylesheet" href="assets/styles.css" />
 <script src="https://cdn.tailwindcss.com"></script>
 <title>Reach – Privacy Policy</title>

--- a/terms.html
+++ b/terms.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="description" content="Project Reach – Peer-support resources for emotional well-being" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha384-..." crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-<link rel="icon" href="assets/favicon.ico" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
+<link rel="icon" href="assets/favicon.png" />
 <link rel="stylesheet" href="assets/styles.css" />
 <script src="https://cdn.tailwindcss.com"></script>
 <title>Reach – Terms of Service</title>
@@ -45,7 +45,7 @@
         <li>You agree to follow respectful conduct toward volunteers and other users.</li>
       </ul>
 
-      <h3>4. Privacy & Anonymity</h3>
+      <h3>4. Privacy &amp; Anonymity</h3>
       <p>
         We don’t collect identifying information. Conversations may be logged anonymously
         for training and safety. Full details are in our <a href="privacy.html">Privacy Policy</a>.
@@ -58,7 +58,7 @@
         <li>Inappropriate behavior may result in access being blocked.</li>
       </ul>
 
-      <h3>6. Availability & Changes</h3>
+      <h3>6. Availability &amp; Changes</h3>
       <p>
         This service is volunteer-led and may not always be available. We reserve the right
         to modify, pause, or terminate any part of the platform at any time.

--- a/volunteer.html
+++ b/volunteer.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="description" content="Project Reach – Peer-support resources for emotional well-being" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha384-..." crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-<link rel="icon" href="assets/favicon.ico" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
+<link rel="icon" href="assets/favicon.png" />
 <link rel="stylesheet" href="assets/styles.css" />
 <script src="https://cdn.tailwindcss.com"></script>
 <title>Volunteer – Reach Collective</title>


### PR DESCRIPTION
## Summary
- correct Google Fonts URL escaping and favicon references
- escape ampersands in Terms of Service
- clarify README lint instructions

## Testing
- `bash scripts/setup.sh`
- `for f in *.html; do tidy -q -e "$f"; xmllint --noout "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6847de729938832bbd1ace9f2d937a01