### PR TITLE
Enable site-wide dark mode

### DIFF
--- a/about.html
+++ b/about.html
@@ -88,9 +88,19 @@
     });
   </script>
 <div id="footer"></div>
+<script src="scripts/dark_mode.js"></script>
 <script>
-fetch('assets/partials/header.html').then(r => r.text()).then(html => document.getElementById('header').innerHTML = html);
-fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
+fetch('assets/partials/header.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('header').innerHTML = html;
+    initDarkModeToggle();
+  });
+fetch('assets/partials/footer.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('footer').innerHTML = html;
+  });
 </script>
 </body>
 </html>

--- a/assets/partials/header.html
+++ b/assets/partials/header.html
@@ -20,5 +20,6 @@
       <li><a href="terms.html">Terms</a></li>
       <li><a href="privacy.html">Privacy</a></li>
     </ul>
+    <button id="themeToggle" aria-label="Toggle dark mode">🌙</button>
   </div>
 </nav>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -199,6 +199,22 @@ footer a:hover {
   cursor: pointer;
 }
 
+/* theme toggle button next to menu */
+/* background none to blend with nav bar */
+/* margin-left gives spacing from menu */
+button#themeToggle {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.25rem;
+  margin-left: 1rem;
+  cursor: pointer;
+}
+
+html.dark button#themeToggle {
+  color: #f7c948;
+}
+
 .nav-menu li a:hover,
 .has-dropdown > button:hover {
   color: #f7c948;
@@ -354,4 +370,32 @@ footer a:hover {
   margin-top: 1rem;
   font-weight: 500;
   font-size: 1rem;
+}
+
+/* Dark mode styles */
+html.dark body {
+  background: #1a202c;
+  color: #f7fafc;
+}
+
+html.dark .box {
+  background-color: #2d3748;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+html.dark a {
+  color: #9ae6b4;
+}
+
+html.dark a:hover {
+  color: #68d391;
+}
+
+html.dark .nav-bar {
+  background-color: #000;
+}
+
+html.dark .footer-extended {
+  color: #cbd5e0;
+  border-top-color: #2d3748;
 }

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -45,9 +45,19 @@
     });
   </script>
 <div id="footer"></div>
+<script src="scripts/dark_mode.js"></script>
 <script>
-fetch('assets/partials/header.html').then(r => r.text()).then(html => document.getElementById('header').innerHTML = html);
-fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
+fetch('assets/partials/header.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('header').innerHTML = html;
+    initDarkModeToggle();
+  });
+fetch('assets/partials/footer.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('footer').innerHTML = html;
+  });
 </script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -46,9 +46,19 @@
     });
   </script>
 <div id="footer"></div>
+<script src="scripts/dark_mode.js"></script>
 <script>
-fetch('assets/partials/header.html').then(r => r.text()).then(html => document.getElementById('header').innerHTML = html);
-fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
+fetch('assets/partials/header.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('header').innerHTML = html;
+    initDarkModeToggle();
+  });
+fetch('assets/partials/footer.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('footer').innerHTML = html;
+  });
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -76,9 +76,15 @@
     });
   </script>
 <div id="footer"></div>
+<script src="scripts/dark_mode.js"></script>
 <script>
-fetch('assets/partials/header.html').then(r => r.text()).then(html => document.getElementById('header').innerHTML = html);
-fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
+  fetch('assets/partials/header.html')
+    .then(r => r.text())
+    .then(html => {
+      document.getElementById('header').innerHTML = html;
+      initDarkModeToggle();
+    });
+  fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
 </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -102,9 +102,19 @@
     });
   </script>
 <div id="footer"></div>
+<script src="scripts/dark_mode.js"></script>
 <script>
-fetch('assets/partials/header.html').then(r => r.text()).then(html => document.getElementById('header').innerHTML = html);
-fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
+fetch('assets/partials/header.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('header').innerHTML = html;
+    initDarkModeToggle();
+  });
+fetch('assets/partials/footer.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('footer').innerHTML = html;
+  });
 </script>
 </body>
 </html>

--- a/scripts/dark_mode.js
+++ b/scripts/dark_mode.js
@@ -1,0 +1,20 @@
+/**
+ * Purpose: Provide persistent dark-mode toggle.
+ * Inputs: localStorage 'theme' and button clicks.
+ * Outputs: Applies 'dark' class to the document root.
+ * Complexity: O(1) per toggle.
+ */
+function applyTheme(theme) {
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+}
+
+function initDarkModeToggle() {
+  const saved = localStorage.getItem('theme');
+  if (saved) applyTheme(saved);
+  const btn = document.getElementById('themeToggle');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const dark = document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  });
+}

--- a/terms.html
+++ b/terms.html
@@ -95,9 +95,19 @@
     });
   </script>
 <div id="footer"></div>
+<script src="scripts/dark_mode.js"></script>
 <script>
-fetch('assets/partials/header.html').then(r => r.text()).then(html => document.getElementById('header').innerHTML = html);
-fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
+fetch('assets/partials/header.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('header').innerHTML = html;
+    initDarkModeToggle();
+  });
+fetch('assets/partials/footer.html')
+  .then(r => r.text())
+  .then(html => {
+    document.getElementById('footer').innerHTML = html;
+  });
 </script>
 </body>
 </html>

--- a/volunteer.html
+++ b/volunteer.html
@@ -93,9 +93,19 @@
   </script>
 
   <div id="footer"></div>
+  <script src="scripts/dark_mode.js"></script>
   <script>
-    fetch('assets/partials/header.html').then(r => r.text()).then(html => document.getElementById('header').innerHTML = html);
-    fetch('assets/partials/footer.html').then(r => r.text()).then(html => document.getElementById('footer').innerHTML = html);
+    fetch('assets/partials/header.html')
+      .then(r => r.text())
+      .then(html => {
+        document.getElementById('header').innerHTML = html;
+        initDarkModeToggle();
+      });
+    fetch('assets/partials/footer.html')
+      .then(r => r.text())
+      .then(html => {
+        document.getElementById('footer').innerHTML = html;
+      });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dark mode toggle button in nav
- persist theme via new `scripts/dark_mode.js`
- style toggle and components for dark mode
- load toggle logic in all pages

## Testing
- `tidy -q -e *.html`
- `for f in *.html; do xmllint --noout $f; done` *(fails: Specification mandates value for attribute required)*

------
https://chatgpt.com/codex/tasks/task_e_6854f93f4fa0832bb7b3160cd4c90eae